### PR TITLE
Add Rate Distortion Optimization options for UASTC

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -233,6 +233,14 @@ class KTX2ExportFormat(bpy.types.PropertyGroup):
         default=1
     )
 
+    rdo_factor: bpy.props.FloatProperty(
+        name="Rate Distortion Optimization (UASTC only)",
+        description="Reduces accuracy in exchange for significantly improved compression ratios (as much as 2x smaller)",
+        min=0,
+        max=10,
+        default=0
+    )
+
     astc: bpy.props.PointerProperty(type=KTX2ExportFormatASTC)
     basisu: bpy.props.PointerProperty(type=KTX2ExportFormatBASISU)
 
@@ -319,6 +327,7 @@ def draw_format(body, props, name, display):
             if props.basisu.compression_mode == 'UASTC':
                 body.prop(props.basisu.uastc, 'quality_level')
                 body.prop(props.basisu.uastc, 'compression_level')
+                body.prop(props, 'rdo_factor')
             elif props.basisu.compression_mode == 'ETC1S':
                 body.prop(props.basisu.etc1s, 'quality_level')
                 body.prop(props.basisu.etc1s, 'compression_level')
@@ -470,6 +479,7 @@ class glTF2ExportUserExtension:
                 compression_mode,
                 quality_level,
                 compression_level,
+                format_props.rdo_factor,
                 self.properties.generate_mipmaps,
                 export_settings,
                 astc_block_size=format_props.astc.astc_block_size,

--- a/__init__.py
+++ b/__init__.py
@@ -156,8 +156,8 @@ class KTX2ExportCompressionUASTC(bpy.types.PropertyGroup):
     )
     compression_level: bpy.props.IntProperty(
         name="Compression",
-        description="UASTC: 1-22 (higher=better)",
-        min=1,
+        description="UASTC: 0-22 (higher=better)",
+        min=0,
         max=22,
         default=3
     )

--- a/ktx2_encode.py
+++ b/ktx2_encode.py
@@ -190,7 +190,7 @@ def save_blender_image_to_temp(blender_image, export_settings):
         return None
 
 
-def encode_image_to_ktx2(gltf_image, target_format, compression_mode, quality_level, compression_level, generate_mipmaps, export_settings, astc_block_size='6x6', oetf='srgb', target_type='RGBA', scale=1.0):
+def encode_image_to_ktx2(gltf_image, target_format, compression_mode, quality_level, compression_level, rdo_level, generate_mipmaps, export_settings, astc_block_size='6x6', oetf='srgb', target_type='RGBA', scale=1.0):
     """
     Encode a glTF image to KTX2 format.
 
@@ -200,6 +200,7 @@ def encode_image_to_ktx2(gltf_image, target_format, compression_mode, quality_le
         compression_mode: 'ETC1S' or 'UASTC' (for BASISU)
         quality_level: Quality level (1-255 for ETC1S, 0-4 for UASTC)
         compression_level: Compression level (0-5 for ETC1S, 1-22 for UASTC)
+        rdo_level: Rate Distortion Optimization level (0 - 10)
         generate_mipmaps: Whether to generate mipmaps
         export_settings: Export settings dict
         astc_block_size: ASTC block size ('4x4', '5x5', '6x6', '8x8')
@@ -232,6 +233,7 @@ def encode_image_to_ktx2(gltf_image, target_format, compression_mode, quality_le
             'format': compression_mode,
             'quality': quality_level,
             'compression': compression_level,
+            'rdo': rdo_level,
             'mipmaps': generate_mipmaps,
             'astc_block_size': astc_block_size,
             'oetf': oetf,

--- a/ktx_tools.py
+++ b/ktx_tools.py
@@ -640,8 +640,10 @@ def run_toktx(input_path, output_path, options=None):
         block_size = options.get('astc_block_size', '6x6')
         cmd.extend(['--astc_blk_d', block_size])
         cmd.extend(['--astc_quality', 'medium'])
+
         compression = options.get('compression', 3)
-        cmd.extend(['--zcmp', str(compression)])
+        if compression > 0:
+            cmd.extend(['--zcmp', str(compression)])
     else:
         # Basis Universal (ETC1S or UASTC) - universal format
         # Can be transcoded to BC7, ASTC, ETC2, etc. at runtime
@@ -650,15 +652,20 @@ def run_toktx(input_path, output_path, options=None):
             cmd.extend(['--encode', 'uastc'])
             quality = options.get('quality', 2)
             cmd.extend(['--uastc_quality', str(quality)])
+
             compression = options.get('compression', 3)
-            cmd.extend(['--zcmp', str(compression)])
+            if compression > 0:
+                cmd.extend(['--zcmp', str(compression)])
+
         else:
             # ETC1S (default)
             cmd.extend(['--encode', 'etc1s'])
             quality = options.get('quality', 128)
             cmd.extend(['--qlevel', str(quality)])
+
             compression = options.get('compression', 1)
-            cmd.extend(['--clevel', str(compression)])
+            if compression > 0:
+                cmd.extend(['--clevel', str(compression)])
     
     # Transfer function
     oetf = options.get('oetf', 'srgb')

--- a/ktx_tools.py
+++ b/ktx_tools.py
@@ -657,6 +657,9 @@ def run_toktx(input_path, output_path, options=None):
             if compression > 0:
                 cmd.extend(['--zcmp', str(compression)])
 
+            rdo = options.get('rdo', 0)
+            if rdo > 0:
+                cmd.extend(['--uastc_rdo_l', str(rdo)])
         else:
             # ETC1S (default)
             cmd.extend(['--encode', 'etc1s'])


### PR DESCRIPTION
I added an option to adjust RDO for UASTC textures. TLDR; it reduces the accuracy a bit to make some blocks identical, which lets them be compressed much better. With UASTC and supercompression (using ZStandard in each individual KTX file), my scene textures were about 68MB. When I disable supercompression and set RDO to the default value (1.0), they're about 78MB. However, the non-RDO textures gain nothing from compression, while the RDO textures compress down to 48.6MB (using 7zip).

Since RDO works very badly at low compression levels, I also made a compression value of 0 disable ZStandard compression. This lets the export be a bit faster while still achieving a good size after packaging into a zip file.